### PR TITLE
Update all links and image src to HTTPS

### DIFF
--- a/html/oauth-deny.html
+++ b/html/oauth-deny.html
@@ -15,7 +15,7 @@
     <![endif]-->
 
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="http://orcid.org/sites/default/files/images/orcid_16x16.png" />
+    <link rel="icon" type="image/png" href="https://orcid.org/sites/default/files/images/orcid_16x16.png" />
   </head>
 
   <body>
@@ -26,7 +26,7 @@
       <div class="masthead">
         <ul class="nav nav-pills pull-right">
           <li><a href="index.php">Home</a></li>
-          <li><a href="http://orcid.org" target="_blank">About ORCID</a></li>
+          <li><a href="https://orcid.org" target="_blank">About ORCID</a></li>
           <li><a href="https://orcid.org/help/contact-us" target="_blank">Contact ORCID</a></li>
         </ul>
         <h3 class="muted">ORCID @ State University</h3>

--- a/html/oauth-redirect-idp.html
+++ b/html/oauth-redirect-idp.html
@@ -15,7 +15,7 @@
     <![endif]-->
 
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="http://orcid.org/sites/default/files/images/orcid_16x16.png" />
+    <link rel="icon" type="image/png" href="https://orcid.org/sites/default/files/images/orcid_16x16.png" />
   </head>
 
   <body>
@@ -26,7 +26,7 @@
       <div class="masthead">
         <ul class="nav nav-pills pull-right">
           <li><a href="index.php">Home</a></li>
-          <li><a href="http://orcid.org" target="_blank">About ORCID</a></li>
+          <li><a href="https://orcid.org" target="_blank">About ORCID</a></li>
           <li><a href="https://orcid.org/help/contact-us" target="_blank">Contact ORCID</a></li>
         </ul>
         <h3 class="muted">ORCID @ State University</h3>
@@ -36,7 +36,7 @@
 
       <div class="jumbotron">
 			<h1>Thanks Josiah Carberry!</h1>
-      <p class="lead">Your ORCID <img src="http://orcid.org/sites/default/files/images/orcid_16x16.png" class="logo" width='16' height='16' alt="iD"/> http://orcid.org/0000-0002-1825-0097 is now connected to State University</p>
+      <p class="lead">Your ORCID <img src="https://orcid.org/sites/default/files/images/orcid_16x16.png" class="logo" width='16' height='16' alt="iD"/> https://orcid.org/0000-0002-1825-0097 is now connected to State University</p>
       <p class="lead">We've posted information about your role at State University to your ORCID record. Please review your record to confirm that the information is correct. If you notice any errors, please contact <a href="mailto:orcid@stateuniversity.edu">orcid@stateuniversity.edu</a> .</p>
       <br> <br>
       <a class="btn btn-large"  href="https://orcid.org/my-orcid" target="_blank">View your ORCID record</a>

--- a/html/oauth-redirect.html
+++ b/html/oauth-redirect.html
@@ -15,7 +15,7 @@
     <![endif]-->
 
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="http://orcid.org/sites/default/files/images/orcid_16x16.png" />
+    <link rel="icon" type="image/png" href="https://orcid.org/sites/default/files/images/orcid_16x16.png" />
   </head>
 
   <body>
@@ -25,7 +25,7 @@
       <div class="masthead">
         <ul class="nav nav-pills pull-right">
           <li><a href="https://orcid-create-on-demand.herokuapp.com/">Home</a></li>
-          <li><a href="http://orcid.org" target="_blank">About ORCID</a></li>
+          <li><a href="https://orcid.org" target="_blank">About ORCID</a></li>
           <li><a href="https://orcid.org/help/contact-us" target="_blank">Contact ORCID</a></li>
         </ul>
         <h3 class="muted">ORCID @ State University</h3>
@@ -36,7 +36,7 @@
       <div class="jumbotron">
 			<h1>Thanks Josiah Carberry!</h1>
 			<br>
-			<p class="lead">Your ORCID <img src="http://orcid.org/sites/default/files/images/orcid_16x16.png" class="logo" width='16' height='16' alt="iD"/> is http://orcid.org/0000-0002-1825-0097</p>
+			<p class="lead">Your ORCID <img src="https://orcid.org/sites/default/files/images/orcid_16x16.png" class="logo" width='16' height='16' alt="iD"/> is https://orcid.org/0000-0002-1825-0097</p>
 			<p class="lead">The access token we're storing in our database so that we can update your ORCID record in the future is <b>XXXXXXXXXXXXXXXXXXXXXXXXX</b></p>
 			<p>(for demo purposes only - don't show access tokens in live apps!)</p>
 			<br> <br>

--- a/index.php
+++ b/index.php
@@ -15,7 +15,7 @@
     <![endif]-->
 
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="http://orcid.org/sites/default/files/images/orcid_16x16.png" />
+    <link rel="icon" type="image/png" href="https://orcid.org/sites/default/files/images/orcid_16x16.png" />
   </head>
 
   <body>
@@ -25,7 +25,7 @@
       <div class="masthead">
         <ul class="nav nav-pills pull-right">
           <li class="active"><a href="https://orcid-create-on-demand.herokuapp.com/">Home</a></li>
-          <li><a href="http://orcid.org" target="_blank">About ORCID</a></li>
+          <li><a href="https://orcid.org" target="_blank">About ORCID</a></li>
           <li><a href="https://orcid.org/help/contact-us" target="_blank">Contact ORCID</a></li>
         </ul>
         <h3 class="muted">ORCID @ State University</h3>
@@ -38,10 +38,10 @@
         <br>
         <p class="lead">Click the button below to create an ORCID iD and connect it to State University's faculty profile system.</p>
         <!--replace client_id and redirect_uri with your own values-->
-        <a class="btn btn-large" href="https://orcid.org/oauth/authorize?client_id=APP-XXXXXXXXXXXXXXXX&response_type=code&scope=/authenticate&redirect_uri=http://your-redirect-uri.org"><img id="orcid-id-logo" src="http://orcid.org/sites/default/files/images/orcid_24x24.png" width='24' height='24' alt="ORCID logo"/> Create a new ORCID iD</a>
+        <a class="btn btn-large" href="https://orcid.org/oauth/authorize?client_id=APP-XXXXXXXXXXXXXXXX&response_type=code&scope=/authenticate&redirect_uri=https://your-redirect-uri.org"><img id="orcid-id-logo" src="https://orcid.org/sites/default/files/images/orcid_24x24.png" width='24' height='24' alt="ORCID logo"/> Create a new ORCID iD</a>
         <br> <br>
         <!--replace client_id and redirect_uri with your own values-->
-        <p class="lead">Already have an ORCID iD? <a href="https://orcid.org/oauth/authorize?client_id=APP-XXXXXXXXXXXXXXXX&response_type=code&scope=/authenticate&redirect_uri=http://your-redirect-uri.org&show_login=true">Connect your existing ORCID iD</a>
+        <p class="lead">Already have an ORCID iD? <a href="https://orcid.org/oauth/authorize?client_id=APP-XXXXXXXXXXXXXXXX&response_type=code&scope=/authenticate&redirect_uri=https://your-redirect-uri.org&show_login=true">Connect your existing ORCID iD</a>
       </div>
 
       <hr>

--- a/oauth-deny.php
+++ b/oauth-deny.php
@@ -15,7 +15,7 @@
     <![endif]-->
 
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="http://orcid.org/sites/default/files/images/orcid_16x16.png" />
+    <link rel="icon" type="image/png" href="https://orcid.org/sites/default/files/images/orcid_16x16.png" />
   </head>
 
   <body>
@@ -26,7 +26,7 @@
       <div class="masthead">
         <ul class="nav nav-pills pull-right">
           <li><a href="index.php">Home</a></li>
-          <li><a href="http://orcid.org" target="_blank">About ORCID</a></li>
+          <li><a href="https://orcid.org" target="_blank">About ORCID</a></li>
           <li><a href="https://orcid.org/help/contact-us" target="_blank">Contact ORCID</a></li>
         </ul>
         <h3 class="muted">ORCID @ State University</h3>

--- a/oauth-redirect-idp.php
+++ b/oauth-redirect-idp.php
@@ -15,7 +15,7 @@
     <![endif]-->
 
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="http://orcid.org/sites/default/files/images/orcid_16x16.png" />
+    <link rel="icon" type="image/png" href="https://orcid.org/sites/default/files/images/orcid_16x16.png" />
   </head>
 
   <body>
@@ -27,7 +27,7 @@
 
 define('OAUTH_CLIENT_ID', 'APP-XXXXXXXXXXXXXXXX');//client ID
 define('OAUTH_CLIENT_SECRET', 'XXXXXXXXXXXXXXXXXXXXXX');//client secret
-define('OAUTH_REDIRECT_URI', 'http://your-redirect-uri.org');//redirect URI
+define('OAUTH_REDIRECT_URI', 'https://your-redirect-uri.org');//redirect URI
 
 //ORCID API ENDPOINTS
 ////////////////////////////////////////////////////////////////////////
@@ -95,7 +95,7 @@ if (isset($_GET['code'])) {
       <div class="masthead">
         <ul class="nav nav-pills pull-right">
           <li><a href="index.php">Home</a></li>
-          <li><a href="http://orcid.org" target="_blank">About ORCID</a></li>
+          <li><a href="https://orcid.org" target="_blank">About ORCID</a></li>
           <li><a href="https://orcid.org/help/contact-us" target="_blank">Contact ORCID</a></li>
         </ul>
         <h3 class="muted">ORCID @ State University</h3>
@@ -106,7 +106,7 @@ if (isset($_GET['code'])) {
       <div class="jumbotron">
       <div class="alert alert-success"><h3>Connection complete!</h3></div>
       <h1>Thanks <?php echo $response['name']; ?>!</h1>
-      <p class="lead">We have stored your ORCID <img src="http://orcid.org/sites/default/files/images/orcid_16x16.png" class="logo" width='16' height='16' alt="iD"/> <?php echo $response['orcid']; ?> in State University records.</p>
+      <p class="lead">We have stored your ORCID <img src="https://orcid.org/sites/default/files/images/orcid_16x16.png" class="logo" width='16' height='16' alt="iD"/> <?php echo $response['orcid']; ?> in State University records.</p>
       <p class="lead">We've posted information about your role at State University to your ORCID record. Please review your record to confirm that the information is correct. If you notice any errors, please contact <a href="mailto:orcid@stateuniversity.edu">orcid@stateuniversity.edu</a> .</p>
       <p class="lead">You can revoke State University's permission at any time at <a href="https://orcid.org/account">https://orcid.org/account</a> .</p>
       <br> <br>

--- a/oauth-redirect.php
+++ b/oauth-redirect.php
@@ -15,7 +15,7 @@
     <![endif]-->
 
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="http://orcid.org/sites/default/files/images/orcid_16x16.png" />
+    <link rel="icon" type="image/png" href="https://orcid.org/sites/default/files/images/orcid_16x16.png" />
   </head>
 
   <body>
@@ -27,7 +27,7 @@
 
 define('OAUTH_CLIENT_ID', 'APP-XXXXXXXXXXXXXXXX');//client ID
 define('OAUTH_CLIENT_SECRET', 'XXXXXXXXXXXXXXXXXXXXXX');//client secret
-define('OAUTH_REDIRECT_URI', 'http://your-redirect-uri.org');//redirect URI
+define('OAUTH_REDIRECT_URI', 'https://your-redirect-uri.org');//redirect URI
 
 //ORCID API ENDPOINTS
 ////////////////////////////////////////////////////////////////////////
@@ -91,7 +91,7 @@ if (isset($_GET['code'])) {
       <div class="masthead">
         <ul class="nav nav-pills pull-right">
           <li><a href="https://orcid-create-on-demand.herokuapp.com/">Home</a></li>
-          <li><a href="http://orcid.org" target="_blank">About ORCID</a></li>
+          <li><a href="https://orcid.org" target="_blank">About ORCID</a></li>
           <li><a href="https://orcid.org/help/contact-us" target="_blank">Contact ORCID</a></li>
         </ul>
         <h3 class="muted">ORCID @ State University</h3>
@@ -102,7 +102,7 @@ if (isset($_GET['code'])) {
       <div class="jumbotron">
       <h1>Thanks, <?php echo $response['name']; ?>!</h1>
       <br>
-      <p class="lead">Your ORCID <img src="http://orcid.org/sites/default/files/images/orcid_16x16.png" class="logo" width='16' height='16' alt="iD"/> is <?php echo $response['orcid']; ?></p>
+      <p class="lead">Your ORCID <img src="https://orcid.org/sites/default/files/images/orcid_16x16.png" class="logo" width='16' height='16' alt="iD"/> is <?php echo $response['orcid']; ?></p>
       <p class="lead">The access token we're storing in our database so that we can update your ORCID record in the future is <b><?php echo $response['access_token']; ?></b></p>
       <p>(for demo purposes only - don't show access tokens in live apps!)</p>
       <br> <br>

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 PHP code samples for the following ORCID API use cases:
 
 ##Create on demand
-**[index.php](index.php):** Sample implementation of the ORCID create-on-demand process, as described in http://members.orcid.org/create-records
+**[index.php](index.php):** Sample implementation of the ORCID create-on-demand process, as described in https://members.orcid.org/create-records
 
 View live demo at https://orcid-create-on-demand.herokuapp.com/
 


### PR DESCRIPTION
This updates ORCID links from http:// to https://, partially for use with Heroku (eg on https://orcid-create-on-demand.herokuapp.com/ this change avoids the broken security on that specifically) and partially for good practice overall, as applications following this code will (should) be on HTTPS.
